### PR TITLE
Improves readability of code-in-hyperlinks

### DIFF
--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -109,6 +109,11 @@ const ContentBody = styled.div`
       border-bottom: 2px solid white;
     }
   }
+
+  & :not(pre) a code[class*='language-'] {
+    color: #222222cc;
+    background-color: rgba(255, 229, 100, 0.2);
+  }
 `
 
 class Content extends React.Component {


### PR DESCRIPTION
If you do something like \[\`foo\`\](http://bar)</code>, the link was
rendered with a black background color. Background color and foreground
color are now the same as those for normal inline code.