### PR TITLE
doc(readme): fix 404 in contributor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ asciinema:  true
 MIT
 
 ## Authors
-[Contributors](./graphs/contributors)
+[Contributors](https://github.com/040code/040code.github.io/graphs/contributors)


### PR DESCRIPTION
Hey,
thanks for using my started. I really like the work you did and the improvement you've done (left menu, multiple authors, asciinema...). I've found a small bug on the readme. One link seems to be broken.

https://github.com/040code/040code.github.io/blob/source/graphs/contributors doesn't exist and return 404.

Cheers,
Max